### PR TITLE
polynomial division for general ring coefficients via idLift

### DIFF
--- a/src/libsingular/rings.jl
+++ b/src/libsingular/rings.jl
@@ -108,8 +108,8 @@ function p_EqualPolys(a::poly, b::poly, r::ring)
    icxx"""p_EqualPolys($a, $b, $r);"""
 end
 
-function singclap_pdivide(a::poly, b::poly, r::ring)
-   icxx"""singclap_pdivide($a, $b, $r);"""
+function p_Divide(a::poly, b::poly, r::ring)
+   icxx"""p_Divide($a, $b, $r);"""
 end
 
 function singclap_gcd(a::poly, b::poly, r::ring)

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -219,7 +219,7 @@ function divexact(x::spoly, y::spoly)
    R = parent(x)
    x1 = libSingular.p_Copy(x.ptr, R.ptr)
    y1 = libSingular.p_Copy(y.ptr, R.ptr)
-   p = libSingular.singclap_pdivide(x1, y1, R.ptr)
+   p = libSingular.p_Divide(x1, y1, R.ptr)
    return R(p)
 end
 


### PR DESCRIPTION
substitute singclap_pdivide by the new, more general p_Divide
which calls singclap_pdivide or idLift