### PR TITLE
fix setting ring dependent options redSB and redTail

### DIFF
--- a/src/libsingular/rings.jl
+++ b/src/libsingular/rings.jl
@@ -41,11 +41,19 @@ function  rVar(r::ring)
 end
 
 function rSetOption_redSB(r::ring)
-   icxx"""$r->options |= Sy_bit(OPT_REDSB);"""
+   icxx"""const ring origin = currRing;
+          rChangeCurrRing($r);
+          si_opt_1 |= Sy_bit(OPT_REDSB);
+          rChangeCurrRing(origin);
+       """
 end
 
 function rSetOption_redTail(r::ring)
-   icxx"""$r->options |= Sy_bit(OPT_REDTAIL);"""
+   icxx"""const ring origin = currRing;
+          rChangeCurrRing($r);
+          si_opt_1 |= Sy_bit(OPT_REDTAIL);
+          rChangeCurrRing(origin);
+       """
 end
 
 function p_Delete(p::poly, r::ring)


### PR DESCRIPTION
si_opt_1 is the global variable in Singular where ring dependent are stored. When the ring is changed from, say, r1 to r2, they are stored in r1->options and r2->options are loaded into si_opt_1.